### PR TITLE
Remove Play, add Google for in-chat googling

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,3 +1,3 @@
 [
-  "play.coffee"
+  "google.coffee"
 ]


### PR DESCRIPTION
This change will remove the Play script from bucket which requires a music server. Music play-ability will continue to be researched.

Adding the google script will allow the first Google result of a search to be returned by bucket within chat.
